### PR TITLE
feat(Editor): 絵文字とユーザのヒントを表示する機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react-dom": "^16.4.2",
     "react-markdown": "^3.4.1",
     "react-scripts": "1.1.4",
-    "react-split-pane": "^0.1.82"
+    "react-split-pane": "^0.1.82",
+    "react-tabs": "^2.2.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "redux": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-saga": "^0.16.0",
+    "remark": "^9.0.0",
+    "remark-html-emoji-image": "^1.0.0",
+    "remark-react": "^4.0.3",
+    "remark-text-to-image": "ganezasan/remark-text-to-image",
+    "remark-toc": "^5.0.0",
     "reselect": "^3.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "axios": "^0.18.0",
     "codemirror": "^5.39.2",
     "emoji-dictionary": "^1.0.9",
     "history": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,21 @@
   "private": true,
   "dependencies": {
     "codemirror": "^5.39.2",
+    "emoji-dictionary": "^1.0.9",
+    "history": "^4.7.2",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "react-codemirror2": "^5.1.0",
     "react-dom": "^16.4.2",
     "react-markdown": "^3.4.1",
+    "react-redux": "^5.0.7",
     "react-scripts": "1.1.4",
     "react-split-pane": "^0.1.82",
-    "react-tabs": "^2.2.2"
+    "react-tabs": "^2.2.2",
+    "redux": "^4.0.0",
+    "redux-logger": "^3.0.6",
+    "redux-saga": "^0.16.0",
+    "reselect": "^3.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.css
+++ b/src/App.css
@@ -8,9 +8,15 @@
 
 .App-main {
   flex: auto;
+  display: flex;
   justify-content: center;
   align-items: center;
-  height: calc(100vh - 50px);
+  margin-top: 20px;
+}
+
+.editor-box {
+  width: 700px;
+  height: 600px;
 }
 
 .App-title {

--- a/src/App.css
+++ b/src/App.css
@@ -42,6 +42,11 @@
   padding: 20px;
 }
 
+.emoji {
+  width: 16px;
+  height: 16px;
+}
+
 @keyframes App-logo-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Provider } from 'react-redux';
 import SplitPane from 'react-split-pane';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 
@@ -20,64 +21,67 @@ class App extends Component {
   }
 
   render() {
+    const { store } = this.props;
     const { src } = this.state;
     return (
-      <div className="App">
-        <header className="App-header">
-          <p className="App-title">Md Editor</p>
-        </header>
-        <div className="App-main">
-          <div className="editor-box">
-            <Tabs style={{ height: '100%' }}>
-              <TabList>
-                <Tab>Separate</Tab>
-                <Tab>Combine</Tab>
-              </TabList>
-              <TabPanel style={{ height: '100%' }}>
-                <SplitPane
-                  split="vertical"
-                  defaultSize="50%"
-                  style={{
-                    position: 'relative',
-                    border: '1px solid rgba(0,0,0,0.1)',
-                  }}
-                >
-                  <Editor src={src} onChangeSrc={this.onMarkdownChange} />
-                  <Viewer src={src} />
-                </SplitPane>
-              </TabPanel>
-              <TabPanel style={{ height: '100%' }}>
-                <Tabs
-                  style={{
-                    height: '100%',
-                  }}
-                >
-                  <TabList>
-                    <Tab>Write</Tab>
-                    <Tab>Preview</Tab>
-                  </TabList>
-                  <TabPanel
+      <Provider store={store}>
+        <div className="App">
+          <header className="App-header">
+            <p className="App-title">Md Editor</p>
+          </header>
+          <div className="App-main">
+            <div className="editor-box">
+              <Tabs style={{ height: '100%' }}>
+                <TabList>
+                  <Tab>Separate</Tab>
+                  <Tab>Combine</Tab>
+                </TabList>
+                <TabPanel style={{ height: '100%' }}>
+                  <SplitPane
+                    split="vertical"
+                    defaultSize="50%"
                     style={{
-                      height: '100%',
+                      position: 'relative',
                       border: '1px solid rgba(0,0,0,0.1)',
                     }}
                   >
                     <Editor src={src} onChangeSrc={this.onMarkdownChange} />
-                  </TabPanel>
-                  <TabPanel
+                    <Viewer src={src} />
+                  </SplitPane>
+                </TabPanel>
+                <TabPanel style={{ height: '100%' }}>
+                  <Tabs
                     style={{
                       height: '100%',
-                      border: '1px solid rgba(0,0,0,0.1)',
                     }}
                   >
-                    <Viewer src={src} />
-                  </TabPanel>
-                </Tabs>
-              </TabPanel>
-            </Tabs>
+                    <TabList>
+                      <Tab>Write</Tab>
+                      <Tab>Preview</Tab>
+                    </TabList>
+                    <TabPanel
+                      style={{
+                        height: '100%',
+                        border: '1px solid rgba(0,0,0,0.1)',
+                      }}
+                    >
+                      <Editor src={src} onChangeSrc={this.onMarkdownChange} />
+                    </TabPanel>
+                    <TabPanel
+                      style={{
+                        height: '100%',
+                        border: '1px solid rgba(0,0,0,0.1)',
+                      }}
+                    >
+                      <Viewer src={src} />
+                    </TabPanel>
+                  </Tabs>
+                </TabPanel>
+              </Tabs>
+            </div>
           </div>
         </div>
-      </div>
+      </Provider>
     );
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
-import { Provider } from 'react-redux';
+import { Provider, connect } from 'react-redux';
 import SplitPane from 'react-split-pane';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import { load } from './redux/emoji/actions';
 
 import './App.css';
 import { Editor, Viewer } from './components';
@@ -11,6 +12,10 @@ class App extends Component {
   state = {
     src: '# Hello world',
   };
+
+  componentDidMount() {
+    this.props.load();
+  }
 
   onMarkdownChange = this.onMarkdownChange.bind(this);
 
@@ -86,4 +91,11 @@ class App extends Component {
   }
 }
 
-export default App;
+const mapDispatchToProps = {
+  load,
+};
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(App);

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import SplitPane from 'react-split-pane';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 
 import './App.css';
 import { Editor, Viewer } from './components';
+import 'react-tabs/style/react-tabs.css';
 
 class App extends Component {
   state = {
@@ -25,10 +27,55 @@ class App extends Component {
           <p className="App-title">Md Editor</p>
         </header>
         <div className="App-main">
-          <SplitPane split="vertical" defaultSize="50%">
-            <Editor src={src} onChangeSrc={this.onMarkdownChange} />
-            <Viewer src={src} />
-          </SplitPane>
+          <div className="editor-box">
+            <Tabs style={{ height: '100%' }}>
+              <TabList>
+                <Tab>Separate</Tab>
+                <Tab>Combine</Tab>
+              </TabList>
+              <TabPanel style={{ height: '100%' }}>
+                <SplitPane
+                  split="vertical"
+                  defaultSize="50%"
+                  style={{
+                    position: 'relative',
+                    border: '1px solid rgba(0,0,0,0.1)',
+                  }}
+                >
+                  <Editor src={src} onChangeSrc={this.onMarkdownChange} />
+                  <Viewer src={src} />
+                </SplitPane>
+              </TabPanel>
+              <TabPanel style={{ height: '100%' }}>
+                <Tabs
+                  style={{
+                    height: '100%',
+                  }}
+                >
+                  <TabList>
+                    <Tab>Write</Tab>
+                    <Tab>Preview</Tab>
+                  </TabList>
+                  <TabPanel
+                    style={{
+                      height: '100%',
+                      border: '1px solid rgba(0,0,0,0.1)',
+                    }}
+                  >
+                    <Editor src={src} onChangeSrc={this.onMarkdownChange} />
+                  </TabPanel>
+                  <TabPanel
+                    style={{
+                      height: '100%',
+                      border: '1px solid rgba(0,0,0,0.1)',
+                    }}
+                  >
+                    <Viewer src={src} />
+                  </TabPanel>
+                </Tabs>
+              </TabPanel>
+            </Tabs>
+          </div>
         </div>
       </div>
     );

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -18,21 +18,17 @@ const hintRender = (elt, data, cur) => {
   return elt;
 };
 
-const makeHintLists = (target, list, makeText, makeDisplayText, className) => {
-  console.log(list);
-  console.log(target);
-
-  return list.filter(l => l.indexOf(target) !== -1).map((key, i) => ({
+const makeHintLists = (target, list, makeText, makeDisplayText, className) =>
+  list.filter(l => l.indexOf(target) !== -1).map((key, i) => ({
     text: makeText(key),
     displayText: makeDisplayText(key),
     className,
     i,
     render: hintRender,
   }));
-};
 
 const emojiList = ['apple', 'abc', 'axz', 'bee', 'beam', 'bleach'].map(
-  key => `:${key}: `,
+  key => `${key}: `,
 );
 const mentionList = [
   'taka',
@@ -41,7 +37,7 @@ const mentionList = [
   'tanaka',
   'tachibana',
   'takashi',
-].map(key => `@${key} `); // 最後にスペース入れることで、選択が終わりというのが表現できている
+].map(key => `${key} `); // 最後にスペース入れることで、選択が終わりというのが表現できている
 
 class Editor extends Component {
   state = {
@@ -50,7 +46,7 @@ class Editor extends Component {
 
   autoComplete = cm => {
     cm.showHint({
-      hint: editor => {
+      hint: () => {
         const cur = cm.getCursor();
         const token = cm.getTokenAt(cur);
         const start = token.start;
@@ -58,10 +54,10 @@ class Editor extends Component {
 
         if (token.string.indexOf('@') === 0) {
           const list = makeHintLists(
-            token.string,
+            token.string.slice(1),
             mentionList,
+            key => `@${key}`,
             key => `${key}`,
-            key => `${key.slice(1)}`,
             'menthionList',
           );
 
@@ -73,10 +69,10 @@ class Editor extends Component {
         }
         if (token.string.indexOf(':') === 0) {
           const list = makeHintLists(
-            token.string,
+            token.string.slice(1),
             emojiList,
-            key => `${key}`,
-            key => `${key}`,
+            key => `:${key}`,
+            key => `:${key}`,
             'emojiList',
           );
           return {
@@ -87,19 +83,16 @@ class Editor extends Component {
         }
       },
       completeSingle: false,
-      closeCharacters: /[\s()\[\]{};>,]/, // eslint-disable-line no-useless-escape
     });
   };
 
   render() {
     const { onChangeSrc } = this.props;
     const options = {
-      mode: 'markdown',
+      mode: 'gfm',
       theme: 'material',
       lineNumbers: true,
       lineWrapping: true,
-      completeSingle: false,
-      completeOnSingleClick: false,
     };
 
     return (

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -5,145 +5,20 @@ import { Controlled as CodeMirror } from 'react-codemirror2';
 import { createStructuredSelector } from 'reselect';
 import { connect } from 'react-redux';
 import { getList } from '../redux/emoji/selectors';
+import { autoComplete } from './autoComplete';
 
 require('codemirror/addon/hint/show-hint');
 require('codemirror/addon/hint/show-hint.css');
 require('codemirror/mode/gfm/gfm'); // without this css hints won't show
 require('codemirror/addon/search/searchcursor');
 
-const hintRender = (elt, data, cur) => {
-  const displayNode = `<img width="15" height="15" src="${
-    cur.url
-  }" alt="icon" async></img> ${cur.displayText}`;
-  elt.innerHTML = displayNode;
-  elt.hintId = cur.i;
-  return elt;
-};
-
-const makeHintLists = (
-  target,
-  list,
-  makeText,
-  makeDisplayText,
-  className,
-  original,
-) =>
-  list.filter(l => l.indexOf(target) !== -1).map((key, i) => ({
-    text: makeText(key),
-    displayText: makeDisplayText(key),
-    className,
-    i,
-    render: hintRender,
-    url: original[key],
-  }));
-
-const makeEmojiList = list => Object.keys(list).map(key => `${key}`);
-const mentionList = [
-  'taka',
-  'koyo',
-  'kato',
-  'tanaka',
-  'tachibana',
-  'takashi',
-].reduce((keyValue, key) => {
-  keyValue[key] =
-    'https://github.global.ssl.fastly.net/images/icons/emoji/+1.png?v5';
-  return keyValue;
-}, {});
-
 class Editor extends Component {
   state = {
     value: this.props.src,
   };
 
-  autoComplete = cm => {
-    cm.showHint({
-      hint: () => {
-        const pattern = /@[A-Za-z0-9]*$/;
-
-        const currentPos = cm.getCursor();
-        const sc = cm.getSearchCursor(pattern, currentPos, {
-          multiline: false,
-        });
-
-        if (sc.findPrevious()) {
-          const isInputtingEmoji =
-            currentPos.line === sc.to().line && currentPos.ch === sc.to().ch;
-          if (!isInputtingEmoji) {
-            return;
-          }
-        } else {
-          return;
-        }
-
-        const matched = cm.getDoc().getRange(sc.from(), sc.to());
-        const term = matched.replace('@', ''); // remove '@' in the head
-
-        const list = Object.keys(mentionList)
-          .filter(l => l.indexOf(term) !== -1)
-          .map((key, i) => ({
-            text: `@${key} `,
-            displayText: `${key}`,
-            className: ['mention'],
-            i,
-            render: hintRender,
-            url: mentionList[key],
-          }));
-
-        return {
-          list,
-          from: sc.from(),
-          to: sc.to(),
-        };
-
-        // const cur = cm.getCursor();
-        // const token = cm.getTokenAt(cur);
-        // const start = token.start;
-        // const end = token.ch;
-        //
-        // console.log(cur);
-        // console.log(token);
-        // if (token.string.indexOf('@') === 0) {
-        //   const list = makeHintLists(
-        //     token.string.slice(1),
-        //     Object.keys(mentionList).map(key => `${key}`),
-        //     key => `@${key} `,
-        //     key => `${key}`,
-        //     'menthionList',
-        //     mentionList,
-        //   );
-        //
-        //   return {
-        //     list,
-        //     from: codemirror.Pos(cur.line, start),
-        //     to: codemirror.Pos(cur.line, end),
-        //   };
-        // }
-        // if (token.string.indexOf(':') === 0) {
-        //   const list = makeHintLists(
-        //     token.string.slice(1),
-        //     makeEmojiList(this.props.emojiList),
-        //     key => `:${key}: `,
-        //     key => `:${key}: `,
-        //     'emojiList',
-        //     this.props.emojiList,
-        //   );
-        //   return {
-        //     list,
-        //     from: codemirror.Pos(cur.line, start),
-        //     to: codemirror.Pos(cur.line, end),
-        //   };
-        // }
-      },
-      disableKeywords: false,
-      completeSingle: false,
-      completeOnSingleClick: false,
-      closeCharacters: /[\s()\[\]{};>,]/, // eslint-disable-line no-useless-escape
-    });
-  };
-
   render() {
-    const { onChangeSrc } = this.props;
+    const { onChangeSrc, emojiList } = this.props;
     const options = {
       mode: 'gfm',
       theme: 'material',
@@ -161,7 +36,7 @@ class Editor extends Component {
         className="editor-pane"
         height="100%"
         onBeforeChange={(editor, data, value) => {
-          this.autoComplete(editor);
+          autoComplete(editor, emojiList);
           this.setState({
             value,
           });
@@ -177,6 +52,7 @@ class Editor extends Component {
 Editor.propTypes = {
   src: PropTypes.string,
   onChangeSrc: PropTypes.func,
+  emojiList: PropTypes.object,
 };
 
 const mapStateToProps = createStructuredSelector({

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -2,34 +2,41 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as codemirror from 'codemirror';
 import { Controlled as CodeMirror } from 'react-codemirror2';
+import { createStructuredSelector } from 'reselect';
+import { connect } from 'react-redux';
+import { getList } from '../redux/emoji/selectors';
 
 require('codemirror/addon/hint/show-hint');
 require('codemirror/addon/hint/show-hint.css');
 require('codemirror/mode/markdown/markdown'); // without this css hints won't show
 
 const hintRender = (elt, data, cur) => {
-  const url =
-    'https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png?v8';
-  const displayNode = `<img width="15" height="15" src="${url}" alt="icon" async></img> ${
-    cur.displayText
-  }`;
+  const displayNode = `<img width="15" height="15" src="${
+    cur.url
+  }" alt="icon" async></img> ${cur.displayText}`;
   elt.innerHTML = displayNode;
   elt.hintId = cur.i;
   return elt;
 };
 
-const makeHintLists = (target, list, makeText, makeDisplayText, className) =>
+const makeHintLists = (
+  target,
+  list,
+  makeText,
+  makeDisplayText,
+  className,
+  original,
+) =>
   list.filter(l => l.indexOf(target) !== -1).map((key, i) => ({
     text: makeText(key),
     displayText: makeDisplayText(key),
     className,
     i,
     render: hintRender,
+    url: original[key],
   }));
 
-const emojiList = ['apple', 'abc', 'axz', 'bee', 'beam', 'bleach'].map(
-  key => `${key}: `,
-);
+const makeEmojiList = list => Object.keys(list).map(key => `${key}`);
 const mentionList = [
   'taka',
   'koyo',
@@ -70,10 +77,11 @@ class Editor extends Component {
         if (token.string.indexOf(':') === 0) {
           const list = makeHintLists(
             token.string.slice(1),
-            emojiList,
-            key => `:${key}`,
-            key => `:${key}`,
+            makeEmojiList(this.props.emojiList),
+            key => `:${key}: `,
+            key => `:${key}: `,
             'emojiList',
+            this.props.emojiList,
           );
           return {
             list,
@@ -123,4 +131,11 @@ Editor.propTypes = {
   onChangeSrc: PropTypes.func,
 };
 
-export default Editor;
+const mapStateToProps = createStructuredSelector({
+  emojiList: getList,
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(Editor);

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -6,19 +6,57 @@ require('codemirror/addon/hint/show-hint');
 require('codemirror/addon/hint/show-hint.css');
 require('codemirror/mode/markdown/markdown'); // without this css hints won't show
 
-const emojiList = ['apple:', ':abc:', 'axz:', 'bee:', 'beam:', 'bleach:'];
+const hintRender = (elt, data, cur) => {
+  const url =
+    'https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png?v8';
+  const displayNode = `<img width="15" height="15" src="${url}" alt="icon" async></img> ${
+    cur.text
+  }`;
+  elt.innerHTML = displayNode;
+  elt.hintId = cur.i;
+  return elt;
+};
+
+const emojiList = ['apple', 'abc', 'axz', 'bee', 'beam', 'bleach'].map(
+  (key, i) => ({
+    text: `${key}:`,
+    className: 'emoji',
+    i,
+    render: hintRender,
+  }),
+);
+
+const mentionList = [
+  'taka',
+  'koyo',
+  'kato',
+  'tanaka',
+  'tachibana',
+  'takashi',
+].map((key, i) => ({
+  text: key,
+  className: 'mention',
+  i,
+  render: hintRender,
+}));
+
+const getHint = (editor, list) => ({
+  hint: () => ({
+    from: editor.getDoc().getCursor(),
+    to: editor.getDoc().getCursor(),
+    list,
+  }),
+  closeCharacters: /[\s()\[\]{};>,]/,
+  completeSingle: false,
+});
+
 class Editor extends Component {
-  handleKeyUpEvent(editor, target) {
+  handleKeyDown(editor, target) {
     if (target.key === '@') {
-      const options = {
-        hint() {
-          return {
-            from: editor.getDoc().getCursor(),
-            to: editor.getDoc().getCursor(),
-            list: emojiList,
-          };
-        },
-      };
+      const options = getHint(editor, mentionList);
+      editor.showHint(options);
+    } else if (target.key === ':') {
+      const options = getHint(editor, emojiList);
       editor.showHint(options);
     }
   }
@@ -41,7 +79,7 @@ class Editor extends Component {
         options={options}
         className="editor-pane"
         height="100%"
-        onKeyDown={this.handleKeyUpEvent}
+        onKeyDown={this.handleKeyDown}
         onChange={(editor, target, value) => {
           onChangeSrc(value);
         }}

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -83,6 +83,8 @@ class Editor extends Component {
         }
       },
       completeSingle: false,
+      closeCharacters: /[\s()\[\]{};>,]/, // eslint-disable-line no-useless-escape
+      completeOnSingleClick: false,
     });
   };
 

--- a/src/components/MdPreview.js
+++ b/src/components/MdPreview.js
@@ -1,32 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactMarkdown from 'react-markdown';
-import emoji from 'emoji-dictionary';
+import remark from 'remark';
+import reactRenderer from 'remark-react';
+import textToImage from 'remark-text-to-image';
+import toc from 'remark-toc';
+
 import { createStructuredSelector } from 'reselect';
 import { connect } from 'react-redux';
 import { getList } from '../redux/emoji/selectors';
 
-const makeImage = (name, url) => (
-  <img width="15" height="15" src="${url}" alt="${name}" async />
-);
-
-const emojiSupport = (text, emojiList) =>
-  text.replace(
-    /:\w+:/gi,
-    name => emoji.getUnicode(name),
-    // const key = name.replace(/:/g, '');
-    // TODO 画像にならない
-    // const emojiUrl = emojiList[key];
-    // return emojiUrl ? makeImage(key, emojiUrl) : name;
-  );
-
 const MdPreview = ({ src, emojiList }) => (
-  // console.log(emojiList);
   <div className="md-preview">
-    <ReactMarkdown
-      source={src}
-      renderers={{ text: text => emojiSupport(text, emojiList) }}
-    />
+    {
+      remark()
+        .use(toc)
+        .use(textToImage, {
+          base: 'https://assets-cdn.github.com/images/icons/emoji/unicode/',
+          list: emojiList, // [key: unicode]
+        })
+        .use(reactRenderer, {
+          sanitize: false,
+        })
+        .processSync(src).contents
+    }
   </div>
 );
 

--- a/src/components/MdPreview.js
+++ b/src/components/MdPreview.js
@@ -1,10 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
+import emoji from 'emoji-dictionary';
+import { createStructuredSelector } from 'reselect';
+import { connect } from 'react-redux';
+import { getList } from '../redux/emoji/selectors';
 
-const MdPreview = ({ src }) => (
+const makeImage = (name, url) => (
+  <img width="15" height="15" src="${url}" alt="${name}" async />
+);
+
+const emojiSupport = (text, emojiList) =>
+  text.replace(
+    /:\w+:/gi,
+    name => emoji.getUnicode(name),
+    // const key = name.replace(/:/g, '');
+    // TODO 画像にならない
+    // const emojiUrl = emojiList[key];
+    // return emojiUrl ? makeImage(key, emojiUrl) : name;
+  );
+
+const MdPreview = ({ src, emojiList }) => (
+  // console.log(emojiList);
   <div className="md-preview">
-    <ReactMarkdown source={src} />
+    <ReactMarkdown
+      source={src}
+      renderers={{ text: text => emojiSupport(text, emojiList) }}
+    />
   </div>
 );
 
@@ -12,4 +34,11 @@ MdPreview.propTypes = {
   src: PropTypes.string,
 };
 
-export default MdPreview;
+const mapStateToProps = createStructuredSelector({
+  emojiList: getList,
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(MdPreview);

--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -1,0 +1,87 @@
+const mentionList = [
+  'taka',
+  'koyo',
+  'kato',
+  'tanaka',
+  'tachibana',
+  'takashi',
+].reduce((keyValue, key) => {
+  keyValue[key] =
+    'https://github.global.ssl.fastly.net/images/icons/emoji/+1.png?v5';
+  return keyValue;
+}, {});
+
+const hintRender = (elt, data, cur) => {
+  const displayNode = `<img width="15" height="15" src="${
+    cur.url
+  }" alt="icon" async></img> ${cur.displayText}`;
+  elt.innerHTML = displayNode;
+  elt.hintId = cur.i;
+  return elt;
+};
+
+const makeHint = (list, makeText, className, sc, cm, ejectWord) => {
+  const matched = cm.getDoc().getRange(sc.from(), sc.to());
+  const target = matched.replace(ejectWord, ''); // remove '@' in the head
+  const filteredList = Object.keys(list)
+    .filter(l => l.indexOf(target) !== -1)
+    .slice(0, 20) // 件数を絞る
+    .map((key, i) => ({
+      text: makeText(key),
+      displayText: key,
+      className,
+      i,
+      render: hintRender,
+      url: list[key],
+    }));
+  return {
+    list: filteredList,
+    from: sc.from(),
+    to: sc.to(),
+  };
+};
+
+const makeMentionHint = (list, sc, cm) =>
+  makeHint(list, key => `@${key} `, 'menthionList', sc, cm, '@');
+
+const makeEmojiHint = (list, sc, cm) =>
+  makeHint(list, key => `:${key}: `, 'emojiList', sc, cm, ':');
+
+const getSelector = (cm, pattern, currentPos) => {
+  const sc = cm.getSearchCursor(pattern, currentPos, {
+    multiline: false,
+  });
+
+  if (sc.findPrevious()) {
+    const isInput =
+      currentPos.line === sc.to().line && currentPos.ch === sc.to().ch;
+    if (isInput) {
+      return sc;
+    }
+  }
+  return false;
+};
+
+export const autoComplete = (cm, emojiList) => {
+  cm.showHint({
+    hint: () => {
+      const mentionPattern = /@[A-Za-z0-9]*$/;
+      const emojiPattern = /:[^:\s]*$/;
+
+      const currentPos = cm.getCursor();
+      const mentionSc = getSelector(cm, mentionPattern, currentPos);
+      const emojiSc = getSelector(cm, emojiPattern, currentPos);
+
+      if (mentionSc) {
+        return makeMentionHint(mentionList, mentionSc, cm);
+      }
+      if (emojiSc) {
+        return makeHint(emojiList, emojiSc, cm);
+      }
+    },
+    disableKeywords: false,
+    completeSingle: false,
+    completeOnSingleClick: false,
+    closeCharacters: /[\s()\[\]{};>,]/, // eslint-disable-line no-useless-escape
+  });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,12 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
+import { configureStore, history } from './redux/store/configureStore';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const store = configureStore();
+
+ReactDOM.render(
+  <App store={store} history={history} />,
+  document.getElementById('root'),
+);
 registerServiceWorker();

--- a/src/redux/emoji/actionTypes.js
+++ b/src/redux/emoji/actionTypes.js
@@ -1,0 +1,3 @@
+export default {
+  LOAD_REQUEST: '@MD_EDITOR/EMOJI/LOAD_REQUEST',
+};

--- a/src/redux/emoji/actionTypes.js
+++ b/src/redux/emoji/actionTypes.js
@@ -1,3 +1,4 @@
 export default {
   LOAD_REQUEST: '@MD_EDITOR/EMOJI/LOAD_REQUEST',
+  SAVE: '@MD_EDITOR/EMOJI/SAVE',
 };

--- a/src/redux/emoji/actions.js
+++ b/src/redux/emoji/actions.js
@@ -1,0 +1,5 @@
+import actionTypes from './actionTypes';
+
+export function load() {
+  return { type: actionTypes.LOAD_REQUEST };
+}

--- a/src/redux/emoji/actions.js
+++ b/src/redux/emoji/actions.js
@@ -3,3 +3,12 @@ import actionTypes from './actionTypes';
 export function load() {
   return { type: actionTypes.LOAD_REQUEST };
 }
+
+export function save(list) {
+  return {
+    type: actionTypes.SAVE,
+    payload: {
+      list,
+    },
+  };
+}

--- a/src/redux/emoji/reducer.js
+++ b/src/redux/emoji/reducer.js
@@ -4,29 +4,13 @@ const defaultState = {
   list: {
     '+1':
       'https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png?v8',
-    '-1':
-      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f44e.png?v8',
-    '100':
-      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f4af.png?v8',
-    '1234':
-      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f522.png?v8',
-    '1st_place_medal':
-      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f947.png?v8',
-    '2nd_place_medal':
-      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f948.png?v8',
-    '3rd_place_medal':
-      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f949.png?v8',
-    '8ball':
-      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f3b1.png?v8',
-    a: 'https://assets-cdn.github.com/images/icons/emoji/unicode/1f170.png?v8',
   },
 };
 
 export default function stickTest(state = defaultState, action) {
   switch (action.type) {
-    case actionTypes.LOAD_REQUEST: {
-      // TODO reducer側は何もしない
-      return defaultState;
+    case actionTypes.SAVE: {
+      return { ...state, list: action.payload.list };
     }
     default:
       break;

--- a/src/redux/emoji/reducer.js
+++ b/src/redux/emoji/reducer.js
@@ -1,0 +1,35 @@
+import actionTypes from './actionTypes';
+
+const defaultState = {
+  list: {
+    '+1':
+      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png?v8',
+    '-1':
+      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f44e.png?v8',
+    '100':
+      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f4af.png?v8',
+    '1234':
+      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f522.png?v8',
+    '1st_place_medal':
+      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f947.png?v8',
+    '2nd_place_medal':
+      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f948.png?v8',
+    '3rd_place_medal':
+      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f949.png?v8',
+    '8ball':
+      'https://assets-cdn.github.com/images/icons/emoji/unicode/1f3b1.png?v8',
+    a: 'https://assets-cdn.github.com/images/icons/emoji/unicode/1f170.png?v8',
+  },
+};
+
+export default function stickTest(state = defaultState, action) {
+  switch (action.type) {
+    case actionTypes.LOAD_REQUEST: {
+      // TODO reducer側は何もしない
+      return defaultState;
+    }
+    default:
+      break;
+  }
+  return state;
+}

--- a/src/redux/emoji/saga.js
+++ b/src/redux/emoji/saga.js
@@ -1,0 +1,10 @@
+import { takeLatest } from 'redux-saga/effects';
+import actionTypes from './actionTypes';
+
+function* loadUseCase() {
+  // TODO APIをコールして絵文字リストを取得する
+}
+
+export default function* stickTestSaga() {
+  yield [takeLatest(actionTypes.LOAD_REQUEST, loadUseCase)];
+}

--- a/src/redux/emoji/saga.js
+++ b/src/redux/emoji/saga.js
@@ -1,10 +1,16 @@
-import { takeLatest } from 'redux-saga/effects';
+import { takeLatest, call, put } from 'redux-saga/effects';
+import axios from 'axios';
 import actionTypes from './actionTypes';
+import { save } from './actions';
 
 function* loadUseCase() {
-  // TODO APIをコールして絵文字リストを取得する
+  const emojiList = yield call(() =>
+    axios.get('https://api.github.com/emojis').then(res => res.data),
+  );
+
+  yield put(save(emojiList));
 }
 
-export default function* stickTestSaga() {
+export default function* emojiSaga() {
   yield [takeLatest(actionTypes.LOAD_REQUEST, loadUseCase)];
 }

--- a/src/redux/emoji/selectors.js
+++ b/src/redux/emoji/selectors.js
@@ -1,0 +1,5 @@
+import { createSelector } from 'reselect';
+
+export const emojiSelector = state => state.emoji;
+
+export const getList = createSelector(emojiSelector, emoji => emoji.list);

--- a/src/redux/rootReducer.js
+++ b/src/redux/rootReducer.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import emojiReducer from './emoji/reducer';
+
+const rootReducer = combineReducers({
+  emoji: emojiReducer,
+});
+
+export default rootReducer;

--- a/src/redux/sagas.js
+++ b/src/redux/sagas.js
@@ -1,6 +1,6 @@
-import { all } from 'redux-saga/effects';
+import { fork } from 'redux-saga/effects';
 import emojiSaga from './emoji/saga';
 
 export default function* saga() {
-  yield all(emojiSaga);
+  yield fork(emojiSaga);
 }

--- a/src/redux/sagas.js
+++ b/src/redux/sagas.js
@@ -1,0 +1,6 @@
+import { all } from 'redux-saga/effects';
+import emojiSaga from './emoji/saga';
+
+export default function* saga() {
+  yield all(emojiSaga);
+}

--- a/src/redux/store/configureStore.dev.js
+++ b/src/redux/store/configureStore.dev.js
@@ -1,0 +1,41 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { createHashHistory } from 'history';
+import { createLogger } from 'redux-logger';
+import rootReducer from '../rootReducer';
+import sagas from '../sagas';
+
+const history = createHashHistory();
+
+const logger = createLogger({
+  level: 'info',
+  collapsed: true,
+});
+
+// If Redux DevTools Extension is installed use it, otherwise use Redux compose
+/* eslint-disable no-underscore-dangle */
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+  ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+      // Options: http://extension.remotedev.io/docs/API/Arguments.html
+    })
+  : compose;
+/* eslint-enable no-underscore-dangle */
+// saga
+const sagaMiddleware = createSagaMiddleware();
+const enhancer = composeEnhancers(applyMiddleware(sagaMiddleware, logger));
+
+function configureStore(initialState) {
+  const store = createStore(rootReducer, initialState, enhancer);
+  sagaMiddleware.run(sagas);
+
+  if (module.hot) {
+    module.hot.accept(
+      '../rootReducer',
+      () => store.replaceReducer(require('../rootReducer')), // eslint-disable-line global-require
+    );
+  }
+
+  return store;
+}
+
+export default { configureStore, history };

--- a/src/redux/store/configureStore.js
+++ b/src/redux/store/configureStore.js
@@ -1,0 +1,5 @@
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./configureStore.prod').default; // eslint-disable-line global-require
+} else {
+  module.exports = require('./configureStore.dev').default; // eslint-disable-line global-require
+}

--- a/src/redux/store/configureStore.prod.js
+++ b/src/redux/store/configureStore.prod.js
@@ -1,0 +1,17 @@
+import { createStore, applyMiddleware } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { createHashHistory } from 'history';
+import rootReducer from '../rootReducer';
+import sagas from '../sagas';
+
+const sagaMiddleware = createSagaMiddleware();
+const history = createHashHistory();
+const enhancer = applyMiddleware(sagaMiddleware);
+
+function configureStore(initialState: any) {
+  const store = createStore(rootReducer, initialState, enhancer);
+  sagaMiddleware.run(sagas);
+  return store;
+}
+
+export default { configureStore, history };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@mapbox/hast-util-table-cell-style@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz#5b7166ae01297d72216932b245e4b2f0b642dca6"
+  dependencies:
+    unist-util-visit "^1.3.0"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -224,6 +230,10 @@ array-includes@^3.0.3:
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
+
+array-iterate@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.2.tgz#f66a57e84426f8097f4197fbb6c051b8e5cdf7d8"
 
 array-map@~0.0.0:
   version "0.0.0"
@@ -1353,6 +1363,10 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+ccount@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
+
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -1377,6 +1391,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+character-entities-html4@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.2.tgz#c44fdde3ce66b52e8d321d6c1bf46101f0150610"
 
 character-entities-legacy@^1.0.0:
   version "1.1.2"
@@ -1524,7 +1542,7 @@ codemirror@^5.39.2:
   version "5.39.2"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.39.2.tgz#778aa13b55ebf280745c309cb1b148e3fc06f698"
 
-collapse-white-space@^1.0.2:
+collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
 
@@ -1580,6 +1598,12 @@ combined-stream@1.0.6, combined-stream@~1.0.6:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz#b13793131d9ea2d2431cf5b507ddec258f0ce0db"
+  dependencies:
+    trim "0.0.1"
 
 commander@2.16.x, commander@~2.16.0:
   version "2.16.0"
@@ -1956,6 +1980,12 @@ default-require-extensions@^2.0.0:
   dependencies:
     strip-bom "^3.0.0"
 
+define-properties@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  dependencies:
+    object-keys "^1.0.12"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
@@ -2035,6 +2065,12 @@ des.js@^1.0.0:
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+
+detab@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detab/-/detab-2.0.1.tgz#531f5e326620e2fd4f03264a905fb3bcc8af4df4"
+  dependencies:
+    repeat-string "^1.5.4"
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -2227,6 +2263,10 @@ emoji-names@^1.0.1:
   resolved "https://registry.yarnpkg.com/emoji-names/-/emoji-names-1.0.10.tgz#7d8494c755d4856515844ef32f035f0d2629608f"
   dependencies:
     emoji-name-map "^1.0.0"
+
+"emoji-regex@>=6.0.0 <=6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
 
 emoji-regex@^6.1.0, emoji-regex@^6.5.1:
   version "6.5.1"
@@ -3113,6 +3153,10 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+gemoji@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/gemoji/-/gemoji-4.2.1.tgz#88495f479a2e35a2c693e0ed321933372fc74c68"
+
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
@@ -3138,6 +3182,12 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
+
+github-slugger@^1.0.0, github-slugger@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.0.tgz#8ada3286fd046d8951c3c952a8d7854cfd90fd9a"
+  dependencies:
+    emoji-regex ">=6.0.0 <=6.1.1"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -3350,6 +3400,24 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hast-to-hyperscript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-4.0.0.tgz#3eb25483ec72a8e9a71e4b1ad7eb8f7c86f755db"
+  dependencies:
+    comma-separated-tokens "^1.0.0"
+    is-nan "^1.2.1"
+    kebab-case "^1.0.0"
+    property-information "^3.0.0"
+    space-separated-tokens "^1.0.0"
+    trim "0.0.1"
+    unist-util-is "^2.0.0"
+
+hast-util-sanitize@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-1.2.0.tgz#1a46bc8e8554f4747d219dd1d85f9cb245b1b08d"
+  dependencies:
+    xtend "^4.0.1"
 
 he@1.1.x:
   version "1.1.1"
@@ -3664,6 +3732,10 @@ is-alphabetical@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
 
+is-alphanumeric@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
+
 is-alphanumerical@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
@@ -3813,6 +3885,12 @@ is-installed-globally@^0.1.0:
   dependencies:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
+
+is-nan@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.2.1.tgz#9faf65b6fb6db24b7f5c0628475ea71f988401e2"
+  dependencies:
+    define-properties "^1.1.1"
 
 is-npm@^1.0.0:
   version "1.0.0"
@@ -4397,6 +4475,10 @@ jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+kebab-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.0.tgz#3f9e4990adcad0c686c0e701f7645868f75f91eb"
+
 killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
@@ -4561,6 +4643,10 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
+longest-streak@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.2.tgz#2421b6ba939a443bb9ffebf596585a50b4c38e2e"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -4629,6 +4715,10 @@ markdown-escapes@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
 
+markdown-table@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -4649,6 +4739,51 @@ mdast-add-list-metadata@^1.0.1:
   resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
   dependencies:
     unist-util-visit-parents "1.1.2"
+
+mdast-util-compact@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz#cdb5f84e2b6a2d3114df33bd05d9cb32e3c4083a"
+  dependencies:
+    unist-util-modify-children "^1.0.0"
+    unist-util-visit "^1.1.0"
+
+mdast-util-definitions@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz#673f4377c3e23d3de7af7a4fe2214c0e221c5ac7"
+  dependencies:
+    unist-util-visit "^1.0.0"
+
+mdast-util-to-hast@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-3.0.2.tgz#26b1971f49d6db1e3428463a12e66c89db5021cb"
+  dependencies:
+    collapse-white-space "^1.0.0"
+    detab "^2.0.0"
+    mdast-util-definitions "^1.2.0"
+    mdurl "^1.0.1"
+    trim "0.0.1"
+    trim-lines "^1.0.0"
+    unist-builder "^1.0.1"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.0"
+    xtend "^4.0.1"
+
+mdast-util-to-string@^1.0.0, mdast-util-to-string@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.0.4.tgz#5c455c878c9355f0c1e7f3e8b719cf583691acfb"
+
+mdast-util-toc@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-toc/-/mdast-util-toc-2.1.0.tgz#82b6b218577bb0e67b23abf5c3f7ac73a4b5389f"
+  dependencies:
+    github-slugger "^1.1.1"
+    mdast-util-to-string "^1.0.2"
+    unist-util-visit "^1.1.0"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -5052,7 +5187,7 @@ object-hash@^1.1.4:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
 
-object-keys@^1.0.11, object-keys@^1.0.8:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
@@ -5241,7 +5376,7 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
-parse-entities@^1.1.0:
+parse-entities@^1.0.2, parse-entities@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
   dependencies:
@@ -5753,6 +5888,10 @@ prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+property-information@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
+
 proxy-addr@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
@@ -6196,6 +6335,14 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remark-html-emoji-image@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remark-html-emoji-image/-/remark-html-emoji-image-1.0.0.tgz#6a315ad6d0466d9c6c95b687abf9f83c58b48ddb"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    gemoji "^4.0.0"
+    unist-util-visit "^1.0.0"
+
 remark-parse@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
@@ -6215,6 +6362,64 @@ remark-parse@^5.0.0:
     unist-util-remove-position "^1.0.0"
     vfile-location "^2.0.0"
     xtend "^4.0.1"
+
+remark-react@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/remark-react/-/remark-react-4.0.3.tgz#980938f3bcc93bef220215b26b0b0a80f3158c7d"
+  dependencies:
+    "@mapbox/hast-util-table-cell-style" "^0.1.3"
+    hast-to-hyperscript "^4.0.0"
+    hast-util-sanitize "^1.0.0"
+    mdast-util-to-hast "^3.0.0"
+
+remark-slug@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/remark-slug/-/remark-slug-5.1.0.tgz#e55cd92d53395665e26b2994441394127d860abf"
+  dependencies:
+    github-slugger "^1.0.0"
+    mdast-util-to-string "^1.0.0"
+    unist-util-visit "^1.0.0"
+
+remark-stringify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-5.0.0.tgz#336d3a4d4a6a3390d933eeba62e8de4bd280afba"
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^1.1.0"
+    mdast-util-compact "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
+remark-text-to-image@ganezasan/remark-text-to-image:
+  version "1.0.0"
+  resolved "git+ssh://git@github.com/ganezasan/remark-text-to-image.git#09d3bebc40b803b111ac7f463610168c3cf0f240"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    unist-util-visit "^1.0.0"
+
+remark-toc@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-toc/-/remark-toc-5.0.0.tgz#f1e13ed11062ad4d102b02e70168bd85015bf129"
+  dependencies:
+    mdast-util-toc "^2.0.0"
+    remark-slug "^5.0.0"
+
+remark@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-9.0.0.tgz#c5cfa8ec535c73a67c4b0f12bfdbd3a67d8b2f60"
+  dependencies:
+    remark-parse "^5.0.0"
+    remark-stringify "^5.0.0"
+    unified "^6.0.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -6665,6 +6870,12 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+space-separated-tokens@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz#e95ab9d19ae841e200808cd96bc7bd0adbbb3412"
+  dependencies:
+    trim "0.0.1"
+
 spdx-correct@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
@@ -6805,6 +7016,15 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+
+stringify-entities@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.2.tgz#a98417e5471fd227b3e45d3db1861c11caf668f7"
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 strip-ansi@3.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -7060,6 +7280,10 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
+trim-lines@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.1.tgz#da738ff58fa74817588455e30b11b85289f2a396"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -7150,7 +7374,7 @@ unherit@^1.0.4:
     inherits "^2.0.1"
     xtend "^4.0.1"
 
-unified@^6.1.5:
+unified@^6.0.0, unified@^6.1.5:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
   dependencies:
@@ -7184,9 +7408,29 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
-unist-util-is@^2.1.2:
+unist-builder@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-1.0.3.tgz#ab0f9d0f10936b74f3e913521955b0478e0ff036"
+  dependencies:
+    object-assign "^4.1.0"
+
+unist-util-generated@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.2.tgz#8b993f9239d8e560be6ee6e91c3f7b7208e5ce25"
+
+unist-util-is@^2.0.0, unist-util-is@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
+
+unist-util-modify-children@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz#c7f1b91712554ee59c47a05b551ed3e052a4e2d1"
+  dependencies:
+    array-iterate "^1.0.0"
+
+unist-util-position@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.1.tgz#8e220c24658239bf7ddafada5725ed0ea1ebbc26"
 
 unist-util-remove-position@^1.0.0:
   version "1.1.2"
@@ -7208,7 +7452,7 @@ unist-util-visit-parents@^2.0.0:
   dependencies:
     unist-util-is "^2.1.2"
 
-unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -353,6 +353,13 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 axobject-query@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
@@ -3054,6 +3061,12 @@ flatten@^1.0.2:
 follow-redirects@^1.0.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.2.tgz#5a9d80e0165957e5ef0c1210678fc5c4acb9fb03"
+  dependencies:
+    debug "^3.1.0"
+
+follow-redirects@^1.3.0:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.5.tgz#3c143ca599a2e22e62876687d68b23d55bad788b"
   dependencies:
     debug "^3.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1934,6 +1934,10 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -2194,9 +2198,50 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emoji-chars@^1.0.0:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/emoji-chars/-/emoji-chars-1.0.10.tgz#75e221ffe4c0b65d28a4de31b4eb5e8749016874"
+  dependencies:
+    emoji-unicode-map "^1.0.0"
+
+emoji-dictionary@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/emoji-dictionary/-/emoji-dictionary-1.0.9.tgz#c9839774b692c4f62f15dc286adbd3aef45a8796"
+  dependencies:
+    emoji-chars "^1.0.0"
+    emoji-name-map "^1.0.0"
+    emoji-names "^1.0.1"
+    emoji-unicode-map "^1.0.0"
+    emojilib "^2.0.2"
+
+emoji-name-map@^1.0.0, emoji-name-map@^1.1.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/emoji-name-map/-/emoji-name-map-1.2.7.tgz#edee06c45d696c4320bdcad6f8f6e6048cb0f2be"
+  dependencies:
+    emojilib "^2.0.2"
+    iterate-object "^1.3.1"
+    map-o "^2.0.1"
+
+emoji-names@^1.0.1:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/emoji-names/-/emoji-names-1.0.10.tgz#7d8494c755d4856515844ef32f035f0d2629608f"
+  dependencies:
+    emoji-name-map "^1.0.0"
+
 emoji-regex@^6.1.0, emoji-regex@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+
+emoji-unicode-map@^1.0.0:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/emoji-unicode-map/-/emoji-unicode-map-1.1.9.tgz#59f0d9a1a33e2d31ee4c6d9997c05dadbf372c4d"
+  dependencies:
+    emoji-name-map "^1.1.0"
+    iterate-object "^1.3.1"
+
+emojilib@^2.0.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/emojilib/-/emojilib-2.3.0.tgz#1e6f922c4881bf56c915b9a1d97397e8d4ac7094"
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -3310,6 +3355,16 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -3317,6 +3372,10 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^2.5.0:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3567,7 +3626,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -3983,6 +4042,10 @@ istanbul-reports@^1.3.0:
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
   dependencies:
     handlebars "^4.0.3"
+
+iterate-object@^1.3.0, iterate-object@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/iterate-object/-/iterate-object-1.3.2.tgz#24ec15affa5d0039e8839695a21c2cae1f45b66b"
 
 jest-changed-files@^20.0.3:
   version "20.0.3"
@@ -4445,6 +4508,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.17.5:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -4486,7 +4553,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -4498,7 +4565,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -4541,6 +4608,12 @@ makeerror@1.0.x:
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-o@^2.0.1:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/map-o/-/map-o-2.0.8.tgz#9ae875a0477b92c0ae25b048284bc99c9757ae16"
+  dependencies:
+    iterate-object "^1.3.0"
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
@@ -5856,6 +5929,17 @@ react-markdown@^3.4.1:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
+react-redux@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
+  dependencies:
+    hoist-non-react-statics "^2.5.0"
+    invariant "^2.0.0"
+    lodash "^4.17.5"
+    lodash-es "^4.17.5"
+    loose-envify "^1.1.0"
+    prop-types "^15.6.0"
+
 react-scripts@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-1.1.4.tgz#d5c230e707918d6dd2d06f303b10f5222d017c88"
@@ -6018,6 +6102,23 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  dependencies:
+    deep-diff "^0.3.5"
+
+redux-saga@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
+
+redux@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
+  dependencies:
+    loose-envify "^1.1.0"
+    symbol-observable "^1.2.0"
 
 regenerate@^1.2.1:
   version "1.4.0"
@@ -6195,6 +6296,10 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6215,6 +6320,10 @@ resolve-from@^1.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -6804,6 +6913,10 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+
 symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -7232,6 +7345,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -7278,6 +7395,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.10.0:
   version "0.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,6 +1462,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.0:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 clean-css@4.1.x:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
@@ -5669,7 +5673,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -5911,6 +5915,13 @@ react-style-proptype@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.2.1.tgz#7cfeb9b87ec7ab9dcbde9715170ed10c11fb86aa"
   dependencies:
     prop-types "^15.5.4"
+
+react-tabs@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-2.2.2.tgz#2f2935da379889484751d1df47c1b639e5ee835d"
+  dependencies:
+    classnames "^2.2.0"
+    prop-types "^15.5.0"
 
 react@^16.4.2:
   version "16.4.2"


### PR DESCRIPTION
- [x] @でユーザのリストをヒントとして表示する
- [x] :で絵文字のリストをヒントとして表示する
- [x] リストをフィルターする（takaと入力したら、 ヒントリスト(taka,takashi,shinji)にはtaka,takashiしか表示されない）
- [x] ヒントを選択した際に、入力途中の文字列は不要にする（taと入力している途中に、takaを選択したら、tatakaではなく、takaと入力されている）
- [x] ＠でユーザが指定された際には、ビューワー側ではリンクを表示する
- [x] :で絵文字が指定された際には、ビューワー側では絵文字を表示する
